### PR TITLE
Variable 'emotionEngine' is only set in-game.

### DIFF
--- a/js/Gamygdala.js
+++ b/js/Gamygdala.js
@@ -315,8 +315,8 @@ TUDelft.Gamygdala.prototype.appraise = function(belief, affectedAgent){
 	}
 	//print the emotions to the console for debugging
 	if (this.debug){
-		emotionEngine.printAllEmotions(false);
-		//emotionEngine.printAllEmotions(true);
+		this.printAllEmotions(false);
+		//this.printAllEmotions(true);
 	}
 }
 


### PR DESCRIPTION
The core Gamygdala engine should not refer to itself via a variable.

This current set-up works in the demos because `emotionEngine` is a global variable, but that variable wouldn't be set for a standalone Gamygdala instance.
